### PR TITLE
Allow indexing only latest version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Lunr](https://lunrjs.com/) provides a great search experience without the need for external, server-side, search services.
 It makes it possible to add an *offline* search engine in your Antora's documentation site.
- 
+
 ## Usage
 
 ### Generate an index file
@@ -98,6 +98,18 @@ For instance, as a command line:
 
 ```console
 $ DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr antora site.yml
+```
+
+### Configuration
+
+To index only the latest (released) version, set the following environment variable:
+
+* `DOCSEARCH_INDEX_VERSION=latest`
+
+For instance, as a command line:
+
+```console
+$ DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr DOCSEARCH_INDEX_VERSION=latest antora site.yml
 ```
 
 ### Testing this module

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -40,8 +40,8 @@ function generateIndex (playbook, pages, contentCatalog, env) {
       const $metaRobots = $('meta[name=robots]')
       const indexable = !(($metaRobots && $metaRobots.attr('content') === 'noindex') ||
                         (page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''))
-      const indexOnlyLatest = env['DOCSEARCH_INDEX_VERSION'] &&
-                              env['DOCSEARCH_INDEX_VERSION'] === 'latest'
+      const indexOnlyLatest = env.DOCSEARCH_INDEX_VERSION &&
+                              env.DOCSEARCH_INDEX_VERSION === 'latest'
 
       if (indexOnlyLatest) {
         const component = contentCatalog.getComponent(page.src.component)

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -41,16 +41,17 @@ function generateIndex (playbook, pages, contentCatalog, env) {
 
       const metaRobotNoIndex = $metaRobots && $metaRobots.attr('content') === 'noindex'
       const pageNoIndex = page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''
-      const noIndex = !(metaRobotNoIndex || pageNoIndex)
+      const noIndex = metaRobotNoIndex || pageNoIndex
       const indexOnlyLatest = env.DOCSEARCH_INDEX_VERSION &&
                               env.DOCSEARCH_INDEX_VERSION === 'latest'
       if (indexOnlyLatest) {
         const component = contentCatalog.getComponent(page.src.component)
         const thisVersion = contentCatalog.getComponentVersion(component, page.src.version)
         const latestVersion = contentCatalog.getComponent(page.src.component).latest
-        return noIndex && thisVersion === latestVersion
+        const notLatest = thisVersion !== latestVersion
+        return !(noIndex || notLatest)
       }
-      return noIndex
+      return !noIndex
     })
     .map(({ page, $ }) => {
       // Fetch just the article content, so we don't index the TOC and other on-page text

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -15,7 +15,7 @@ const entities = new Entities()
  * @param {Object} playbook - The configuration object for Antora.
  * @param {Array<File>} pages - The publishable pages to map.
  * @param {Object} contentCatalog - the Antora content catalog (allows access to page metadata).
- * @param {Object} env - command line environmnet variables.
+ * @param {Object} env - command line environment variables.
  * @returns {Object} A JSON object with a Lunr index and a documents store.
  */
 function generateIndex (playbook, pages, contentCatalog, env) {
@@ -38,19 +38,19 @@ function generateIndex (playbook, pages, contentCatalog, env) {
     // Exclude pages marked as "noindex"
     .filter(({ page, $ }) => {
       const $metaRobots = $('meta[name=robots]')
-      const indexable = !(($metaRobots && $metaRobots.attr('content') === 'noindex') ||
-                        (page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''))
+
+      const metaRobotNoIndex = $metaRobots && $metaRobots.attr('content') === 'noindex'
+      const pageNoIndex = page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''
+      const noIndex = !(metaRobotNoIndex || pageNoIndex)
       const indexOnlyLatest = env.DOCSEARCH_INDEX_VERSION &&
                               env.DOCSEARCH_INDEX_VERSION === 'latest'
-
       if (indexOnlyLatest) {
         const component = contentCatalog.getComponent(page.src.component)
         const thisVersion = contentCatalog.getComponentVersion(component, page.src.version)
         const latestVersion = contentCatalog.getComponent(page.src.component).latest
-        return indexable && thisVersion === latestVersion
-      } else {
-        return indexable
+        return noIndex && thisVersion === latestVersion
       }
+      return noIndex
     })
     .map(({ page, $ }) => {
       // Fetch just the article content, so we don't index the TOC and other on-page text

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -13,12 +13,12 @@ const entities = new Entities()
  * @memberof generate-index
  *
  * @param {Object} playbook - The configuration object for Antora.
- * @param {Object} playbook.site - Site-related configuration data.
- * @param {String} playbook.site.url - The base URL of the site.
  * @param {Array<File>} pages - The publishable pages to map.
+ * @param {Object} contentCatalog - the Antora content catalog (allows access to page metadata).
+ * @param {Object} env - command line environmnet variables.
  * @returns {Object} A JSON object with a Lunr index and a documents store.
  */
-function generateIndex (playbook, pages) {
+function generateIndex (playbook, pages, contentCatalog, env) {
   let siteUrl = playbook.site.url
   if (!siteUrl) {
     // Uses relative links when site URL is not set
@@ -38,7 +38,19 @@ function generateIndex (playbook, pages) {
     // Exclude pages marked as "noindex"
     .filter(({ page, $ }) => {
       const $metaRobots = $('meta[name=robots]')
-      return !(($metaRobots && $metaRobots.attr('content') === 'noindex') || (page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''))
+      const indexable = !(($metaRobots && $metaRobots.attr('content') === 'noindex') ||
+                        (page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes.noindex === ''))
+      const indexOnlyLatest = env['DOCSEARCH_INDEX_VERSION'] &&
+                              env['DOCSEARCH_INDEX_VERSION'] === 'latest'
+
+      if (indexOnlyLatest) {
+        const component = contentCatalog.getComponent(page.src.component)
+        const thisVersion = contentCatalog.getComponentVersion(component, page.src.version)
+        const latestVersion = contentCatalog.getComponent(page.src.component).latest
+        return indexable && thisVersion === latestVersion
+      } else {
+        return indexable
+      }
     })
     .map(({ page, $ }) => {
       // Fetch just the article content, so we don't index the TOC and other on-page text

--- a/test/mock-content-catalog.js
+++ b/test/mock-content-catalog.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { posix: path } = require('path')
+
+const SPACE_RX = / /g
+
+function mockContentCatalog (seed = []) {
+  if (!Array.isArray(seed)) seed = [seed]
+  const familyDirs = {
+    alias: 'pages',
+    example: 'examples',
+    image: 'images',
+    nav: '',
+    page: 'pages',
+    partial: 'pages/_partials',
+  }
+  const components = {}
+  const entries = []
+  const entriesById = {}
+  const entriesByPath = {}
+  const entriesByFamily = {}
+  seed.forEach(({ component, version, module: module_, family, relative, contents, mediaType, navIndex, indexify }) => {
+    if (component == null) component = 'component-a'
+    if (version == null) version = 'master'
+    if (module_ == null) module_ = 'module-a'
+    if (!family) family = 'page'
+    if (!contents) contents = ''
+    let versions
+    if (component in components) {
+      versions = components[component].versions
+      if (versions.findIndex((it) => it.version === version) < 0) versions.unshift({ version })
+    } else {
+      components[component] = { name: component, versions: (versions = [{ version }]) }
+    }
+    // NOTE assume we want the latest to be the last version we register
+    components[component].latest = versions[0]
+    const componentVersionKey = buildComponentVersionKey(component, version)
+    const componentRelativePath = path.join(module_ ? 'modules' : '', module_, familyDirs[family], relative)
+    const entry = {
+      path: componentRelativePath,
+      dirname: path.dirname(componentRelativePath),
+      contents: Buffer.from(contents),
+      src: {
+        path: componentRelativePath,
+        component,
+        version,
+        module: module_ || undefined,
+        relative,
+        family,
+        basename: path.basename(relative),
+        stem: path.basename(relative, path.extname(relative)),
+      },
+    }
+    if (mediaType) entry.src.mediaType = entry.mediaType = mediaType
+    const pubVersion = version === 'master' ? '' : version
+    const pubModule = module_ === 'ROOT' ? '' : module_
+    if (family === 'page' || family === 'alias' || family === 'image') {
+      if (!~('/' + relative).indexOf('/_')) {
+        const relativeOut = family === 'image' ? relative : relative.slice(0, -5) + (indexify ? '/' : '.html')
+        entry.out = {
+          path: path.join(component, pubVersion, pubModule, relativeOut),
+          moduleRootPath: relative.includes('/')
+            ? Array(relative.split('/').length - (indexify ? 0 : 1))
+              .fill('..')
+              .join('/')
+            : indexify
+              ? '..'
+              : '.',
+        }
+        let url = '/' + entry.out.path
+        if (~url.indexOf(' ')) url = url.replace(SPACE_RX, '%20')
+        entry.pub = { url, moduleRootPath: entry.out.moduleRootPath }
+      }
+    } else if (family === 'nav') {
+      entry.pub = {
+        url: '/' + path.join(component, pubVersion, pubModule) + '/',
+        moduleRootPath: '.',
+      }
+      entry.nav = { index: navIndex }
+    }
+    const byIdKey = componentVersionKey + (module_ || '') + ':' + family + '$' + relative
+    const byPathKey = componentVersionKey + componentRelativePath
+    entries.push(entry)
+    entriesById[byIdKey] = entriesByPath[byPathKey] = entry
+    if (!(family in entriesByFamily)) entriesByFamily[family] = []
+    entriesByFamily[family].push(entry)
+  })
+
+  return {
+    getComponent: (name) => components[name],
+    getComponents: () => Object.values(components),
+    getComponentVersion: (component, version) =>
+      (typeof component === 'string' ? components[component] : component).versions.find((it) => it.version === version)
+  }
+}
+
+function buildComponentVersionKey (component, version) {
+  return version + '@' + component + ':'
+}
+
+module.exports = mockContentCatalog
+

--- a/test/mock-content-catalog.js
+++ b/test/mock-content-catalog.js
@@ -1,5 +1,13 @@
 'use strict'
 
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* This source code is taken frome the Antora test suite with minor modifications
+ *  see https://gitlab.com/antora/antora/-/blob/master/test/mock-content-catalog.js
+ *  Copyright © 2017-2020 by OpenDevise Inc. and the individual contributors to Antora. */
+
 const { posix: path } = require('path')
 
 const SPACE_RX = / /g

--- a/test/mock-content-catalog.js
+++ b/test/mock-content-catalog.js
@@ -12,7 +12,7 @@ function mockContentCatalog (seed = []) {
     image: 'images',
     nav: '',
     page: 'pages',
-    partial: 'pages/_partials',
+    partial: 'pages/_partials'
   }
   const components = {}
   const entries = []
@@ -48,8 +48,8 @@ function mockContentCatalog (seed = []) {
         relative,
         family,
         basename: path.basename(relative),
-        stem: path.basename(relative, path.extname(relative)),
-      },
+        stem: path.basename(relative, path.extname(relative))
+      }
     }
     if (mediaType) entry.src.mediaType = entry.mediaType = mediaType
     const pubVersion = version === 'master' ? '' : version
@@ -65,7 +65,7 @@ function mockContentCatalog (seed = []) {
               .join('/')
             : indexify
               ? '..'
-              : '.',
+              : '.'
         }
         let url = '/' + entry.out.path
         if (~url.indexOf(' ')) url = url.replace(SPACE_RX, '%20')
@@ -74,7 +74,7 @@ function mockContentCatalog (seed = []) {
     } else if (family === 'nav') {
       entry.pub = {
         url: '/' + path.join(component, pubVersion, pubModule) + '/',
-        moduleRootPath: '.',
+        moduleRootPath: '.'
       }
       entry.nav = { index: navIndex }
     }
@@ -99,4 +99,3 @@ function buildComponentVersionKey (component, version) {
 }
 
 module.exports = mockContentCatalog
-

--- a/test/mock-content-catalog.js
+++ b/test/mock-content-catalog.js
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* This source code is taken frome the Antora test suite with minor modifications
+/* This source code is taken frome the Antora test suite with some removals
  *  see https://gitlab.com/antora/antora/-/blob/master/test/mock-content-catalog.js
  *  Copyright © 2017-2020 by OpenDevise Inc. and the individual contributors to Antora. */
 

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ describe('Generate index', () => {
     const featuresPage = index.store['/antora/1.0/features/']
     expect(featuresPage.text).to.equal('Automate the assembly of your secure, nimble static site as changes happen instead of wrestling with a CMS giant.')
   })
-  it('if so configured, should only index the latest version when there are multiple versions', () => {
+  it('should only index the latest version when there are multiple versions and DOCSEARCH_INDEX_VERSION=latest', () => {
     const playbook = {
       site: {
         url: 'https://docs.antora.org'

--- a/test/test.js
+++ b/test/test.js
@@ -465,22 +465,22 @@ describe('Generate index', () => {
     }]
     const contentCatalog = mockContentCatalog(
       [{
-          component: 'hello',
-          version: '1.0',
-          module: 'module-a',
-          family: 'page',
-          relative: 'antora/1.0/features/',
-          contents: 'not provided'
+        component: 'hello',
+        version: '1.0',
+        module: 'module-a',
+        family: 'page',
+        relative: 'antora/1.0/features/',
+        contents: 'not provided'
       },
       {
-          component: 'hello',
-          version: '1.5',
-          module: 'module-a',
-          family: 'page',
-          relative: 'antora/1.5/features/',
-          contents: 'not provided'
+        component: 'hello',
+        version: '1.5',
+        module: 'module-a',
+        family: 'page',
+        relative: 'antora/1.5/features/',
+        contents: 'not provided'
       }])
-    const env = {'DOCSEARCH_INDEX_VERSION': 'latest'}
+    const env = { DOCSEARCH_INDEX_VERSION: 'latest' }
     const index = generateIndex(playbook, pages, contentCatalog, env)
     expect(index.index.search('spinnacle').length).to.equal(1)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -468,17 +468,13 @@ describe('Generate index', () => {
         component: 'hello',
         version: '1.0',
         module: 'module-a',
-        family: 'page',
-        relative: 'antora/1.0/features/',
-        contents: 'not provided'
+        family: 'page'
       },
       {
         component: 'hello',
         version: '1.5',
         module: 'module-a',
-        family: 'page',
-        relative: 'antora/1.5/features/',
-        contents: 'not provided'
+        family: 'page'
       }])
     const env = { DOCSEARCH_INDEX_VERSION: 'latest' }
     const index = generateIndex(playbook, pages, contentCatalog, env)


### PR DESCRIPTION
using `DOCSEARCH_INDEX_VERSION=latest`, closes #25.

I've tried to write a test using the (slightly stripped back) `mock-content-catalog` from Antora. It is probably the first time I've written a test so I'd welcome feedback.

Perhaps we need to reference that this comes from Antora in the code, I'm not sure what the best way is to do this but I guess I'm interested in whether you think this is a good approach or not (maybe it is more complicated than necessary).

I've also removed a bit of white space.