### PR TITLE
Resolves #38: use relative paths as (source) pub.rootPath + (target) pub.url

### DIFF
--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -25,7 +25,6 @@ function generateIndex (playbook, pages, contentCatalog, env) {
     siteUrl = ''
   }
   if (siteUrl.charAt(siteUrl.length - 1) === '/') siteUrl = siteUrl.substr(0, siteUrl.length - 1)
-  const urlPath = extractUrlPath(siteUrl)
   if (!pages.length) return {}
   // Map of Lunr ref to document
   const documentsStore = {}
@@ -92,7 +91,7 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         component: page.src.component,
         version: page.src.version,
         name: page.src.stem,
-        url: urlPath + page.pub.url,
+        url: page.pub.url,
         titles: titles // TODO get title id to be able to use fragment identifier
       }
     })
@@ -127,15 +126,6 @@ function generateIndex (playbook, pages, contentCatalog, env) {
     index: lunrIndex,
     store: documentsStore
   }
-}
-// Extract the path from an URL
-function extractUrlPath (url) {
-  if (url) {
-    if (url.charAt() === '/') return url
-    const urlPath = new URL(url).pathname
-    return urlPath === '/' ? '' : urlPath
-  }
-  return ''
 }
 
 // Helper function allowing Antora to create a site asset containing the index

--- a/supplemental_ui/js/vendor/search.js
+++ b/supplemental_ui/js/vendor/search.js
@@ -112,7 +112,8 @@ window.antoraLunr = (function (lunr) {
     var documentHit = document.createElement('div')
     documentHit.classList.add('search-result-document-hit')
     var documentHitLink = document.createElement('a')
-    documentHitLink.href = item.ref
+    var rootPath = window.antora.basePath
+    documentHitLink.href = rootPath + item.ref
     documentHit.appendChild(documentHitLink)
     hits.forEach(function (hit) {
       documentHitLink.appendChild(hit)

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('Generate index', () => {
     const contentCatalog = {}
     const env = {}
     const index = generateIndex(playbook, pages, contentCatalog, env)
-    const installPage = index.store['/docs/component-a/install-foo']
+    const installPage = index.store['/component-a/install-foo']
     expect(installPage.text).to.equal('foo')
     expect(installPage.component).to.equal('component-a')
     expect(installPage.version).to.equal('2.0')
@@ -521,9 +521,9 @@ describe('Generate index', () => {
       const contentCatalog = {}
       const env = {}
       const index = generateIndex(playbook, pages, contentCatalog, env)
-      expect(index.store['/docs/component-a/install-foo'].url).to.equal('/docs/component-a/install-foo')
+      expect(index.store['/component-a/install-foo'].url).to.equal('/component-a/install-foo')
     })
-    it('should use absolute links when site URL is an absolute local path (using file:// protocol)', () => {
+    it('should use relative links when site URL is an absolute local path (using file:// protocol)', () => {
       const playbook = {
         site: {
           url: 'file:///path/to/docs'
@@ -543,7 +543,7 @@ describe('Generate index', () => {
       const contentCatalog = {}
       const env = {}
       const index = generateIndex(playbook, pages, contentCatalog, env)
-      expect(index.store['/path/to/docs/component-a/install-foo'].url).to.equal('/path/to/docs/component-a/install-foo')
+      expect(index.store['/component-a/install-foo'].url).to.equal('/component-a/install-foo')
     })
   })
 })


### PR DESCRIPTION
I didn't explicitly test this on a site but I've been using the changes in the @djencks/antora-lunr pipeline extension and associated lunr-ui extension for some time with no problems.