### PR TITLE
Generate correct URLs when the site URL has a path

### DIFF
--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -26,7 +26,6 @@ function generateIndex (playbook, pages, contentCatalog, env) {
     siteUrl = ''
   }
   if (siteUrl.charAt(siteUrl.length - 1) === '/') siteUrl = siteUrl.substr(0, siteUrl.length - 1)
-  let siteUrlPath = new URL(siteUrl).pathname;
   if (!pages.length) return {}
   // Map of Lunr ref to document
   const documentsStore = {}
@@ -92,6 +91,16 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         .replace(/\s+/g, ' ')
         .trim()
 
+      // Prepend the site URL's path if one exists
+      let url = page.pub.url;
+      if (siteUrl.startsWith('http')) {
+          let siteUrlPath = '';
+          siteUrlPath = new URL(siteUrl).pathname;
+          if (siteUrlPath != '' && siteUrlPath != '/') {
+              url = siteUrlPath + url;
+          }
+      }
+
       // Return the indexable content, organized by type
       return {
         text: text,
@@ -99,7 +108,7 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         component: page.src.component,
         version: page.src.version,
         name: page.src.stem,
-        url: siteUrlPath + page.pub.url,
+        url: url,
         titles: titles // TODO get title id to be able to use fragment identifier
       }
     })

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const url = require('url')
 const lunr = require('lunr')
 const cheerio = require('cheerio')
 const Entities = require('html-entities').AllHtmlEntities
@@ -92,13 +91,13 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         .trim()
 
       // Prepend the site URL's path if one exists
-      let url = page.pub.url;
+      let url = page.pub.url
       if (siteUrl.startsWith('http')) {
-          let siteUrlPath = '';
-          siteUrlPath = new URL(siteUrl).pathname;
-          if (siteUrlPath != '' && siteUrlPath != '/') {
-              url = siteUrlPath + url;
-          }
+        let siteUrlPath = ''
+        siteUrlPath = new URL(siteUrl).pathname
+        if (siteUrlPath !== '' && siteUrlPath !== '/') {
+          url = siteUrlPath + url
+        }
       }
 
       // Return the indexable content, organized by type

--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const url = require('url')
 const lunr = require('lunr')
 const cheerio = require('cheerio')
 const Entities = require('html-entities').AllHtmlEntities
@@ -25,6 +26,7 @@ function generateIndex (playbook, pages, contentCatalog, env) {
     siteUrl = ''
   }
   if (siteUrl.charAt(siteUrl.length - 1) === '/') siteUrl = siteUrl.substr(0, siteUrl.length - 1)
+  let siteUrlPath = new URL(siteUrl).pathname;
   if (!pages.length) return {}
   // Map of Lunr ref to document
   const documentsStore = {}
@@ -97,7 +99,7 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         component: page.src.component,
         version: page.src.version,
         name: page.src.stem,
-        url: page.pub.url,
+        url: siteUrlPath + page.pub.url,
         titles: titles // TODO get title id to be able to use fragment identifier
       }
     })

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('Generate index', () => {
     const contentCatalog = {}
     const env = {}
     const index = generateIndex(playbook, pages, contentCatalog, env)
-    const installPage = index.store['/component-a/install-foo']
+    const installPage = index.store['/docs/component-a/install-foo']
     expect(installPage.text).to.equal('foo')
     expect(installPage.component).to.equal('component-a')
     expect(installPage.version).to.equal('2.0')


### PR DESCRIPTION
When the Antora site URL has a path, e.g. `https://example.com/foo`, the document is available at `https://example.com/foo/component/version/page.html`, but clicking a search result will redirect to `/component/version/page.html`. `foo` is lost here and this leads to a 404. This PR should fix this.

