### PR TITLE
Add params to generateIndex()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const generateIndex = require('antora-lunr')
 In the `generateSite` function add the following two lines after `const siteFiles = mapSite(playbook, pages).concat(produceRedirects(playbook, contentCatalog))`:
 
 ```js
-const index = generateIndex(playbook, pages)
+const index = generateIndex(playbook, pages, contentCatalog, env)
 siteFiles.push(generateIndex.createIndexFile(index))
 ```
 


### PR DESCRIPTION
We need to add two parameters to generateIndex() in order to avoid:
```
error: Cannot read property DOCSEARCH_INDEX_VERSION of undefined
  at /usr/local/lib/node_modules/antora-lunr/lib/generate-index.js:44:35
```