### PR TITLE
Moving basePath and pagePath to hidden input due to CSP

### DIFF
--- a/supplemental_ui/js/vendor/search.js
+++ b/supplemental_ui/js/vendor/search.js
@@ -1,5 +1,9 @@
 /* eslint-env browser */
 window.antoraLunr = (function (lunr) {
+  window.antora = window.antora || {}
+  window.antora.basePath = document.getElementById('antora-basePath').value
+  window.antora.pagePath = document.getElementById('antora-pagePath').value
+
   var searchInput = document.getElementById('search-input')
   var searchResult = document.createElement('div')
   searchResult.classList.add('search-result-dropdown-menu')

--- a/supplemental_ui/js/vendor/search.js
+++ b/supplemental_ui/js/vendor/search.js
@@ -1,9 +1,8 @@
 /* eslint-env browser */
 window.antoraLunr = (function (lunr) {
-  window.antora = window.antora || {}
-  window.antora.basePath = document.getElementById('antora-basePath').value
-  window.antora.pagePath = document.getElementById('antora-pagePath').value
-
+  const scriptAttrs = document.getElementById('search-script').dataset
+  const basePath = scriptAttrs.basePath
+  const pagePath = scriptAttrs.pagePath
   var searchInput = document.getElementById('search-input')
   var searchResult = document.createElement('div')
   searchResult.classList.add('search-result-dropdown-menu')
@@ -116,7 +115,7 @@ window.antoraLunr = (function (lunr) {
     var documentHit = document.createElement('div')
     documentHit.classList.add('search-result-document-hit')
     var documentHitLink = document.createElement('a')
-    var rootPath = window.antora.basePath
+    var rootPath = basePath
     documentHitLink.href = rootPath + item.ref
     documentHit.appendChild(documentHitLink)
     hits.forEach(function (hit) {

--- a/supplemental_ui/partials/footer-scripts.hbs
+++ b/supplemental_ui/partials/footer-scripts.hbs
@@ -1,9 +1,7 @@
-<input type="hidden" id="antora-basePath" value="{{or siteRootPath (or site.url siteRootUrl)}}">
-<input type="hidden" id="antora-pagePath" value="{{@root.page.url}}">
 <script src="{{uiRootPath}}/js/site.js"></script>
 {{#if (eq env.DOCSEARCH_ENGINE 'lunr')}}
 <script src="{{uiRootPath}}/js/vendor/lunr.js"></script>
-<script src="{{uiRootPath}}/js/vendor/search.js"></script>
+<script src="{{uiRootPath}}/js/vendor/search.js" id="search-script" data-base-path="{{or siteRootPath (or site.url siteRootUrl)}}" data-page-path="{{@root.page.url}}"></script>
 <script async src="{{uiRootPath}}/../search-index.js"></script>
 {{/if}}
 <script async src="{{uiRootPath}}/js/vendor/highlight.js"></script>

--- a/supplemental_ui/partials/footer-scripts.hbs
+++ b/supplemental_ui/partials/footer-scripts.hbs
@@ -1,8 +1,5 @@
-<script>
-  window.antora = window.antora || {}
-  window.antora.basePath = '{{or siteRootPath (or site.url siteRootUrl)}}'
-  window.antora.pagePath = '{{@root.page.url}}'
-</script>
+<input type="hidden" id="antora-basePath" value="{{or siteRootPath (or site.url siteRootUrl)}}">
+<input type="hidden" id="antora-pagePath" value="{{@root.page.url}}">
 <script src="{{uiRootPath}}/js/site.js"></script>
 {{#if (eq env.DOCSEARCH_ENGINE 'lunr')}}
 <script src="{{uiRootPath}}/js/vendor/lunr.js"></script>


### PR DESCRIPTION
When I try using the default `footer-scripts` partial, my browser refuses to execute the inline script that sets `window.antora`, due to it's Content-security-policy.

This change instead sets the `basePath` and `pagePath` values as hidden inputs, which the JS then fetches for `window.antora`.