### PR TITLE
Update generate-index.js

### DIFF
--- a/lib/generate-index.js
+++ b/lib/generate-index.js
@@ -97,7 +97,7 @@ function generateIndex (playbook, pages, contentCatalog, env) {
         component: page.src.component,
         version: page.src.version,
         name: page.src.stem,
-        url: page.pub.url,
+        url: siteUrl + page.pub.url,
         titles: titles // TODO get title id to be able to use fragment identifier
       }
     })


### PR DESCRIPTION
Proposed fix for https://github.com/Mogztter/antora-lunr/issues/67.

Apparently, the `siteUrl` variable is initialized but never actually used.